### PR TITLE
Refactor .FormField-check to be more isolated from .FormField

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Read more about [SUIT CSS](https://github.com/suitcss/suit/).
 * `FormField-text` - Used to display help text or validation messages
 * `FormField-check` - Wraps around `input` and `label` when using either radio
   or checkbox inputs
+* `FormField-checkInput` - The `input` class when inside `FormField-check`
+* `FormField-checkLabel` - The `label` when inside `FormField-check`
 
 ### States
 
@@ -76,18 +78,18 @@ Blink/Webkit.
 
 ### Checkbox or radio input types
 
-Checkbox and radio inputs require an additional container. This controls
-positioning and allows the `FormField-text` to be rendered beneath:
+Checkbox and radio inputs require an additional container and different class names.
+This controls positioning and allows the `FormField-text` to be rendered beneath:
 
 ```html
 <div class="FormField">
   <label class="FormField-check">
-    <input class="FormField-input" name="shopping" type="radio">
-    <span class="FormField-label">Apples</span>
+    <input class="FormField-checkInput" name="shopping" type="radio">
+    <span class="FormField-checkLabel">Apples</span>
   </label>
   <label class="FormField-check">
-    <input class="FormField-input" name="shopping" type="radio">
-    <span class="FormField-label">Oranges</span>
+    <input class="FormField-checkInput" name="shopping" type="radio">
+    <span class="FormField-checkLabel">Oranges</span>
   </label>
   <span class="FormField-text">Some text about the choices above</span>
 </div>

--- a/lib/form-field.css
+++ b/lib/form-field.css
@@ -46,17 +46,22 @@
 }
 
 .FormField-select,
+.FormField-input,
+.FormField-checkInput {
+  box-sizing: border-box;
+  font-size: var(--FormField-input-fontSize);
+}
+
+.FormField-select,
 .FormField-input {
   background-color: #fff;
   border-color: var(--FormField-input-borderColor);
   border-radius: var(--FormField-input-borderRadius);
   border-style: solid;
   border-width: var(--FormField-input-borderWidth);
-  box-sizing: border-box;
   color: var(--FormField-input-color);
   display: block;
   font-family: var(--FormField-input-fontFamily);
-  font-size: var(--FormField-input-fontSize);
   margin: 0;
   padding: var(--FormField-input-padding);
   width: 100%;
@@ -116,8 +121,6 @@
 }
 
 .FormField-checkInput {
-  box-sizing: border-box;
-  font-size: inherit;
   margin: 0 var(--FormField-check-gutter) 0 0;
   order: 1;
   padding: 0;

--- a/lib/form-field.css
+++ b/lib/form-field.css
@@ -84,8 +84,6 @@
  */
 
 .FormField-input[type="file"],
-.FormField-input[type="checkbox"],
-.FormField-input[type="radio"],
 .FormField-input[type="range"] {
   border: 0;
 }
@@ -117,16 +115,17 @@
   display: flex;
 }
 
-.FormField-check .FormField-input {
-  margin-right: var(--FormField-check-gutter);
+.FormField-checkInput {
+  box-sizing: border-box;
+  font-size: inherit;
+  margin: 0 var(--FormField-check-gutter) 0 0;
   order: 1;
-  width: auto;
+  padding: 0;
 }
 
-.FormField-check .FormField-label {
-  margin-bottom: 0;
+.FormField-checkLabel {
+  color: var(--FormField-label-color);
   order: 2;
-  width: auto;
 }
 
 /**

--- a/test/demo.html
+++ b/test/demo.html
@@ -37,8 +37,8 @@
         <div class="Register-field">
           <div class="FormField">
             <label class="FormField-check">
-              <input class="FormField-input" type="checkbox">
-              <span class="FormField-label">I agree to all marketing material</span>
+              <input class="FormField-checkInput" type="checkbox">
+              <span class="FormField-checkLabel">I agree to all marketing material</span>
             </label>
           </div>
         </div>
@@ -92,8 +92,8 @@
         <div class="Register-field">
           <div class="FormField u-before2of12">
             <label class="FormField-check">
-              <input class="FormField-input" type="checkbox">
-              <span class="FormField-label">I agree to all marketing material</span>
+              <input class="FormField-checkInput" type="checkbox">
+              <span class="FormField-checkLabel">I agree to all marketing material</span>
             </label>
           </div>
         </div>

--- a/test/index.html
+++ b/test/index.html
@@ -115,15 +115,15 @@
   <div class="Test-run">
     <div class="FormField">
       <label class="FormField-check">
-        <input class="FormField-input" type="checkbox">
-        <span class="FormField-label">Surname</span>
+        <input class="FormField-checkInput" type="checkbox">
+        <span class="FormField-checkLabel">Surname</span>
       </label>
     </div>
 
     <div class="FormField">
       <label class="FormField-check">
-        <input class="FormField-input" type="radio">
-        <span class="FormField-label">Surname</span>
+        <input class="FormField-checkInput" type="radio">
+        <span class="FormField-checkLabel">Surname</span>
       </label>
     </div>
   </div>
@@ -132,8 +132,8 @@
   <div class="Test-run">
     <div class="FormField">
       <label class="FormField-check">
-        <span class="FormField-label">Surname</span>
-        <input class="FormField-input" type="checkbox">
+        <span class="FormField-checkLabel">Surname</span>
+        <input class="FormField-checkInput" type="checkbox">
       </label>
     </div>
   </div>
@@ -142,8 +142,8 @@
   <div class="Test-run">
     <div class="FormField">
       <label class="FormField-check">
-        <input class="FormField-input" type="checkbox">
-        <span class="FormField-label">Surname</span>
+        <input class="FormField-checkInput" type="checkbox">
+        <span class="FormField-checkLabel">Surname</span>
       </label>
       <span class="FormField-text">Some text about the choice above</span>
     </div>
@@ -153,16 +153,16 @@
   <div class="Test-run">
     <div class="FormField">
       <label class="FormField-check">
-        <input class="FormField-input" name="shopping" type="radio">
-        <span class="FormField-label">Apples</span>
+        <input class="FormField-checkInput" name="shopping" type="radio">
+        <span class="FormField-checkLabel">Apples</span>
       </label>
       <label class="FormField-check">
-        <input class="FormField-input" name="shopping" type="radio">
-        <span class="FormField-label">Oranges</span>
+        <input class="FormField-checkInput" name="shopping" type="radio">
+        <span class="FormField-checkLabel">Oranges</span>
       </label>
       <label class="FormField-check">
-        <input class="FormField-input" name="shopping" type="radio">
-        <span class="FormField-label">Pears</span>
+        <input class="FormField-checkInput" name="shopping" type="radio">
+        <span class="FormField-checkLabel">Pears</span>
       </label>
       <span class="FormField-text">Some text about the choices above</span>
     </div>


### PR DESCRIPTION
Checkboxes and radios currently have `.FormField-input` applied which removes default background and border on iOS.

This PR isolates `.FormField-check` more by having it's own `.FormField-checkInput` and `.FormField-checkLabel` to avoid this. Display not affected in other browsers.

### Before
![before screenshot](https://i.imgur.com/63ajcL7.png)

![before screenshot](https://i.imgur.com/LdNmv2F.png)

### After
![after screenshot](https://i.imgur.com/0kyLhsW.png)

![after screenshot](https://i.imgur.com/qwpAhvB.png)