### PR TITLE
Disable flex-shrink on .FormField-checkInput

### DIFF
--- a/lib/form-field.css
+++ b/lib/form-field.css
@@ -121,6 +121,7 @@
 }
 
 .FormField-checkInput {
+  flex-shrink: 0;
   margin: 0 var(--FormField-check-gutter) 0 0;
   order: 1;
   padding: 0;


### PR DESCRIPTION
### Current Problem

When text in a checkbox or radio label is so long that it wraps to multiple lines, the more it wraps the more the input is reduced in size by Flexbox.

Have only seen this happen in Mobile Safari.

### Solution

Add `flex-shrink: 0` to `.FormField-checkInput` to prevent the squishing.

### Screenshots

**Before:**
![before screenshot](https://i.imgur.com/2d8qR8z.png)

**After:**
![after screenshot](https://i.imgur.com/BOWLEBt.png)